### PR TITLE
Set environment variables with humilis environment info

### DIFF
--- a/humilis_push_processor/lambda_function/handler/__init__.py
+++ b/humilis_push_processor/lambda_function/handler/__init__.py
@@ -3,6 +3,7 @@
 # preprocessor:jinja2
 
 import logging
+import os
 
 import lambdautils.utils as utils
 import raven
@@ -12,6 +13,10 @@ from .processor import process_event
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+
+os.environ["HUMILIS_ENVIRONMENT"] = "{{_env.name}}"
+os.environ["HUMILIS_STAGE"] = "{{_env.stage}}"
+os.environ["HUMILIS_LAYER"] = "{{_layer.name}}"
 
 
 def produce_io_stream_callables():


### PR DESCRIPTION
This should allow you to use `set_secret(key, value)` and `get_secret(key)` without having to explicitly pass the humilis environment info as a parameters.

Please review.
