### PR TITLE
Deploy Lambda function in a VPC

### DIFF
--- a/humilis_push_processor/meta.yaml.j2
+++ b/humilis_push_processor/meta.yaml.j2
@@ -32,6 +32,17 @@ meta:
                 - sns
                 - s3
 
+        {% if network %}
+            {% if network.vpc_id and network.subnet_id %}
+        meta_network:
+            description: Parameters to put the Lambda in a VPC
+            value:
+                vpc_id: "{{network.vpc_id}}"
+                subnet_id: "{{network.subnet_id}}"
+                security_group_id: "{{network.security_group_id}}"
+            {% endif %}
+        {% endif %}
+
         {% if input %}
         meta_input:
             description: Mapping and filtering for the input events

--- a/humilis_push_processor/resources.yaml.j2
+++ b/humilis_push_processor/resources.yaml.j2
@@ -9,9 +9,10 @@
 {% set _ = globs.update({'has_output_delivery': True}) %}
 {% endif %}
 {% endfor %}
-# set meta_input and meta_error to empty dicts if the user has not provided them
+# set meta parameters to empty dicts if the user has not provided them
 {% set meta_error = meta_error or {} %}
 {% set meta_input = meta_input or {} %}
+{% set meta_network = meta_network or {} %}
 # Do we need a DynamoDB table to store state info?
 {% if dynamodb_capacity.read|int or dynamodb_capacity.write|int %}
 {% set _ = globs.update({'stateful': True}) %}
@@ -52,6 +53,33 @@ resources:
           "Fn::GetAtt":
               - LambdaExecutionRole
               - Arn
+{% if meta_network %}
+        VpcConfig:
+          SubnetIds:
+              - "{{meta_network.subnet_id}}"
+          SecurityGroupIds:
+              {% if meta_network.security_group_id %}
+              - "{{meta_network.security_group_id}}"
+              {% else %}
+              - "Fn::GetAtt":
+                - LambdaSecurityGroup
+                - GroupId
+              {% endif %}
+    {% if not meta_network.security_group_id %}
+    # If the security group id is missing while deploying Lambda in a VPC
+    LambdaSecurityGroup:
+      Type: "AWS::EC2::SecurityGroup"
+      Properties:
+        GroupDescription: "Lambda push-processor security group"
+        SecurityGroupEgress:
+          CidrIp: "0.0.0.0/0"
+          IpProtocol: "-1"
+        Tags:
+          - Key: "Name"
+            Value: "lambda-push-processor"
+        VpcId: "{{meta_network.vpc_id}}"
+    {% endif %}
+{% endif %}
     # The role associated to the Lambda function that processes raw events
     LambdaExecutionRole:
       Type: "AWS::IAM::Role"
@@ -146,7 +174,14 @@ resources:
                     - "Fn::Join":
                       - ""
                       - ["arn:aws:dynamodb:", {"Ref": "AWS::Region"},":", {"Ref": "AWS::AccountId"}, ":", "table/", {"Ref": "StateTable"}]
-                 {% endif %}
+                  {% endif %}
+                - Effect: Allow
+                  # Allow the Lambda to access VPC and create ENI
+                  Action:
+                    - "ec2:CreateNetworkInterface"
+                    - "ec2:DescribeNetworkInterfaces"
+                    - "ec2:DeleteNetworkInterface"
+                  Resource: "*"
     {% if meta_input.kinesis_stream %}
     InputEventSourceMapping:
       Type: "AWS::Lambda::EventSourceMapping"


### PR DESCRIPTION
All cases tested. Works fine even without destroying the push-processor stack : just updating the stack manages to set the lambda inside/outside of a VPC.
The following policy is added permanently (not depending on if we have network parameter in the environment or not) to the lambda role because otherwise passing from a simple Lambda to a Lambda in a VPC was not working without deleting the stack.

```
                - Effect: Allow
                  # Allow the Lambda to access VPC and create ENI
                  Action:
                    - "ec2:CreateNetworkInterface"
                    - "ec2:DescribeNetworkInterfaces"
                    - "ec2:DeleteNetworkInterface"
                  Resource: "*"
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/humilis/humilis-push-processor/5)

<!-- Reviewable:end -->
