### PR TITLE
The push-processor Lambda can notify an SNS topic

### DIFF
--- a/humilis_push_processor/meta.yaml.j2
+++ b/humilis_push_processor/meta.yaml.j2
@@ -32,6 +32,10 @@ meta:
                 - sns
                 - s3
 
+        sns_topic_name:
+            description: A SNS topic the lambda can use to send notifications
+            value:
+
         {% if network %}
             {% if network.vpc_id and network.subnet_id %}
         meta_network:

--- a/humilis_push_processor/resources.yaml.j2
+++ b/humilis_push_processor/resources.yaml.j2
@@ -182,6 +182,16 @@ resources:
                     - "ec2:DescribeNetworkInterfaces"
                     - "ec2:DeleteNetworkInterface"
                   Resource: "*"
+                  {% if sns_topic_name %}
+                - Effect: Allow
+                  # Permission to access a given SNS topic
+                  Action:
+                    - "sns:*"
+                  Resource:
+                    - "Fn::Join":
+                      - ""
+                      - ["arn:aws:sns:", {"Ref": "AWS::Region"},":", {"Ref": "AWS::AccountId"}, ":", "{{sns_topic_name}}"]
+                  {% endif %}
     {% if meta_input.kinesis_stream %}
     InputEventSourceMapping:
       Type: "AWS::Lambda::EventSourceMapping"


### PR DESCRIPTION
As discussed, only add a global sns_topic for the whole push-processor. Not specific topic for each output at the moment.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/humilis/humilis-push-processor/6)

<!-- Reviewable:end -->
